### PR TITLE
Remove Deprecated .needs_migration? Method

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,9 @@ require_relative "../config/environment"
 require "sinatra/activerecord/rake"
 
 RSpec.configure do |config|
-  # Database setup
-  if ActiveRecord::Base.connection.migration_context.needs_migration?
+  config.before(:suite) do
     # Run migrations for test environment
     Rake::Task["db:migrate"].execute
-  end
-
-  config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
 
@@ -36,6 +32,6 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
-  
+
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end


### PR DESCRIPTION
This pull request refactors the database setup in the RSpec configuration to remove a deprecated method `.needs_migration?`

### Test setup improvements:
* [`spec/spec_helper.rb`](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L6-L12): Moved the database migration check and execution into the `config.before(:suite)` block, ensuring migrations are always run before the test suite starts. This change consolidates setup logic and eliminates the conditional check for pending migrations.